### PR TITLE
fix: show updated data on 'mosts' galleries

### DIFF
--- a/app/api/popular/route.ts
+++ b/app/api/popular/route.ts
@@ -1,0 +1,15 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+// Invalidate cached data every 10 seconds (Next.js)
+export const revalidate = 600;
+
+export async function GET() {
+    const popularcharges = await db.charge.findMany({
+        select: { name: true, views: true },
+        orderBy: { views: "desc" },
+        take: 15,
+    });
+
+    return NextResponse.json(popularcharges);
+}

--- a/app/api/recent/route.ts
+++ b/app/api/recent/route.ts
@@ -1,0 +1,15 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+// Invalidate cached data every 10 seconds (Next.js)
+export const revalidate = 10;
+
+export async function GET() {
+    const recentcharges = await db.charge.findMany({
+        select: { name: true, id: true },
+        orderBy: { id: "desc" },
+        take: 15,
+    });
+    return NextResponse.json(recentcharges);
+    // return new Response(JSON.stringify(recentcharges));
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,9 +11,7 @@ export default function Home() {
                     <FraudCheckBox />
                 </div>
                 <div className="m-auto md:flex py-10">
-                    {/* @ts-expect-error Server Component */}
                     <MostPopularCharges />
-                    {/* @ts-expect-error Server Component */}
                     <MostRecentCharges />
                 </div>
             </div>

--- a/components/home/MostPopularCharges.tsx
+++ b/components/home/MostPopularCharges.tsx
@@ -1,20 +1,30 @@
-import { db } from "@/lib/db";
-import ChargeItem from "./ChargeItem";
+"use client";
+import { useState, useEffect } from "react";
+const axios = require("axios").default;
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import ChargeItem from "./ChargeItem";
 
-export const revalidate = 60;
+export default function MostPopularCharges() {
+    const [charges, setCharges] = useState([]);
 
-async function getCharges() {
-    const res = await db.charge.findMany({
-        select: { name: true, views: true },
-        orderBy: { views: "desc" },
-        take: 15,
-    });
-    return res;
-}
+    useEffect(() => {
+        async function fetchData() {
+            const result = await getCharges();
+            setCharges(result.data);
+        }
+        fetchData();
+    }, [charges]);
 
-async function MostPopularCharges() {
-    const charges = await getCharges();
+    async function getCharges() {
+        try {
+            const res = await axios.get("/api/popular");
+            return res;
+        } catch (err) {
+            throw new Error("Failed fetching most popular charges!", {
+                cause: err,
+            });
+        }
+    }
 
     return (
         <Card className="w-full h-auto lg:w-1/2 mr-4">
@@ -25,18 +35,18 @@ async function MostPopularCharges() {
             </CardHeader>
             <CardContent>
                 <ul>
-                    {charges.map((charge) => {
-                        return (
-                            <ChargeItem
-                                key={charge.name}
-                                chargeName={charge.name}
-                            />
-                        );
-                    })}
+                    {Array.isArray(charges)
+                        ? charges.map((charge: any) => {
+                              return (
+                                  <ChargeItem
+                                      key={charge.name}
+                                      chargeName={charge.name}
+                                  />
+                              );
+                          })
+                        : null}
                 </ul>
             </CardContent>
         </Card>
     );
 }
-
-export default MostPopularCharges;

--- a/components/home/MostRecentCharges.tsx
+++ b/components/home/MostRecentCharges.tsx
@@ -1,22 +1,32 @@
+"use client";
+
+import { useState, useEffect } from "react";
+const axios = require("axios").default;
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-
 import ChargeItem from "./ChargeItem";
-import { db } from "@/lib/db";
-import { Charge } from "@prisma/client";
 
-export const revalidate = 10;
+export default function MostRecentCharges() {
+    const [charges, setCharges] = useState([]);
 
-async function getCharges() {
-    const res = await db.charge.findMany({
-        select: { name: true, views: true },
-        orderBy: { id: "desc" },
-        take: 15,
-    });
-    return res;
-}
+    useEffect(() => {
+        async function fetchData() {
+            const result = await getCharges();
+            setCharges(result.data);
+        }
+        fetchData();
+    }, [charges]);
 
-export default async function MostRecentCharges() {
-    const charges = await getCharges();
+    async function getCharges() {
+        try {
+            const res = await axios.get("/api/recent");
+            return res;
+        } catch (err) {
+            throw new Error("Failed fetching most recent charges!", {
+                cause: err,
+            });
+        }
+    }
+
     return (
         <Card className="w-full h-auto my-6 md:my-0 lg:w-1/2">
             <CardHeader>
@@ -26,14 +36,16 @@ export default async function MostRecentCharges() {
             </CardHeader>
             <CardContent>
                 <ul>
-                    {charges.map((charge: any) => {
-                        return (
-                            <ChargeItem
-                                key={charge.name}
-                                chargeName={charge.name}
-                            />
-                        );
-                    })}
+                    {Array.isArray(charges)
+                        ? charges.map((charge: any) => {
+                              return (
+                                  <ChargeItem
+                                      key={charge.name}
+                                      chargeName={charge.name}
+                                  />
+                              );
+                          })
+                        : null}
                 </ul>
             </CardContent>
         </Card>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "b8n",
             "version": "0.1.0",
-            "hasInstallScript": true,
             "dependencies": {
                 "@next-auth/prisma-adapter": "^1.0.6",
                 "@radix-ui/react-accordion": "^1.1.1",
@@ -20,6 +19,7 @@
                 "@types/node": "18.15.11",
                 "@types/react": "18.0.35",
                 "@types/react-dom": "18.0.11",
+                "axios": "^1.4.0",
                 "class-variance-authority": "^0.5.2",
                 "clsx": "^1.2.1",
                 "eslint": "8.38.0",
@@ -1352,6 +1352,11 @@
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
             "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
         "node_modules/autoprefixer": {
             "version": "10.4.14",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
@@ -1402,6 +1407,16 @@
             "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+            "dependencies": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/axobject-query": {
@@ -1628,6 +1643,17 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1759,6 +1785,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/detect-node-es": {
@@ -2480,12 +2514,44 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
         },
+        "node_modules/follow-redirects": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/for-each": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "dependencies": {
                 "is-callable": "^1.1.3"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fraction.js": {
@@ -3344,6 +3410,25 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3992,6 +4077,11 @@
                 "object-assign": "^4.1.1",
                 "react-is": "^16.13.1"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/punycode": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "@types/node": "18.15.11",
         "@types/react": "18.0.35",
         "@types/react-dom": "18.0.11",
+        "axios": "^1.4.0",
         "class-variance-authority": "^0.5.2",
         "clsx": "^1.2.1",
         "eslint": "8.38.0",


### PR DESCRIPTION
alright, this one drove me almost crazy but figured it out.

SITUATION: 
At first, my attempt was making prisma queries in RSC. It worked fine but there was no way for me to revalidate. 

PROBLEM: 
The prisma client that was generated in building for production did not revalidate data which got updated occasionally. 

MY APPROACH: 
Created APIs. Delegated making queries to them. I was aware of fetching data (with fetch()) in a server component via prisma client would cause some latency for updated data. Because I didn't know how cached data will be updated without me specifying. And how the component would be re-rendered.

It turned out I have to specify those since the app is ssr by default. Threw in some revalidation code into api route, changed the component to client component, tied the data I need to a state with a useEffect hook that tracks any change.
